### PR TITLE
1.1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@
 <dependency>
     <groupId>com.platon.sdk</groupId>
     <artifactId>core</artifactId>
-    <version>0.15.1.14</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
 or
 
 ```
-compile "com.platon.sdk:core:0.15.1.14"
+compile "com.platon.sdk:core:1.1.0"
 ```
 
 * use in project

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@
 <dependency>
     <groupId>com.platon.sdk</groupId>
     <artifactId>core</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.0.0</version>
 </dependency>
 ```
 
 or
 
 ```
-compile "com.platon.sdk:core:1.1.0"
+compile "com.platon.sdk:core:1.1.0.0"
 ```
 
 * use in project

--- a/core/src/main/java/com/platon/contracts/ppos/BaseContract.java
+++ b/core/src/main/java/com/platon/contracts/ppos/BaseContract.java
@@ -216,7 +216,8 @@ public abstract class BaseContract extends ManagedTransaction {
     }
 
     private GasProvider getDefaultGasProviderRemote(Function function) throws IOException, EstimateGasException {
-        Transaction transaction = Transaction.createEthCallTransaction(transactionManager.getFromAddress(), contractAddress, EncoderUtils.functionEncoder(function));
+        BigInteger gasPrice = getDefaultGasPrice(function.getType());
+        Transaction transaction = Transaction.createFunctionCallTransaction(transactionManager.getFromAddress(), null, gasPrice, null, contractAddress, EncoderUtils.functionEncoder(function));
         PlatonEstimateGas platonEstimateGas = web3j.platonEstimateGas(transaction).send();
         if(platonEstimateGas.hasError()){
             if(platonEstimateGas.getError().getCode() == ErrorCode.PlatON_Precompiled_Contract_EXEC_FAILED) {
@@ -229,7 +230,7 @@ public abstract class BaseContract extends ManagedTransaction {
             }
         }
         BigInteger gasLimit = Numeric.decodeQuantity(platonEstimateGas.getResult());
-        BigInteger gasPrice = getDefaultGasPrice(function.getType());
+
         return new ContractGasProvider(gasPrice, gasLimit);
     }
 

--- a/core/src/main/java/com/platon/contracts/ppos/BaseContract.java
+++ b/core/src/main/java/com/platon/contracts/ppos/BaseContract.java
@@ -247,8 +247,7 @@ public abstract class BaseContract extends ManagedTransaction {
     }
 
     private GasProvider getDefaultGasProviderRemote(Function function) throws IOException, EstimateGasException {
-        BigInteger gasPrice = getDefaultGasPrice(function.getType());
-        Transaction transaction = Transaction.createFunctionCallTransaction(transactionManager.getFromAddress(), null, gasPrice, null, contractAddress, EncoderUtils.functionEncoder(function));
+        Transaction transaction = Transaction.createEthCallTransaction(transactionManager.getFromAddress(), contractAddress, EncoderUtils.functionEncoder(function));
         PlatonEstimateGas platonEstimateGas = web3j.platonEstimateGas(transaction).send();
         if(platonEstimateGas.hasError()){
             if(platonEstimateGas.getError().getCode() == ErrorCode.PlatON_Precompiled_Contract_EXEC_FAILED) {
@@ -261,7 +260,7 @@ public abstract class BaseContract extends ManagedTransaction {
             }
         }
         BigInteger gasLimit = Numeric.decodeQuantity(platonEstimateGas.getResult());
-
+        BigInteger gasPrice = getDefaultGasPrice(function.getType());
         return new ContractGasProvider(gasPrice, gasLimit);
     }
 

--- a/core/src/main/java/com/platon/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/com/platon/protocol/core/JsonRpc2_0Web3j.java
@@ -2,6 +2,7 @@ package com.platon.protocol.core;
 
 import com.platon.protocol.Web3j;
 import com.platon.protocol.Web3jService;
+import com.platon.protocol.core.methods.DebugWaitSlashingNodeList;
 import com.platon.protocol.core.methods.request.ShhFilter;
 import com.platon.protocol.core.methods.response.*;
 import com.platon.protocol.rx.JsonRpc2_0Rx;
@@ -690,4 +691,22 @@ public class JsonRpc2_0Web3j implements Web3j {
                 web3jService,
                 DebugEconomicConfig.class);
 	}
+
+    @Override
+    public Request<?, PlatonChainId> getChainId() {
+        return new Request<>(
+                "platon_chainId",
+                Collections.<String>emptyList(),
+                web3jService,
+                PlatonChainId.class);
+    }
+
+    @Override
+    public Request<?, DebugWaitSlashingNodeList> getWaitSlashingNodeList() {
+        return new Request<>(
+                "debug_getWaitSlashingNodeList",
+                Collections.<String>emptyList(),
+                web3jService,
+                DebugWaitSlashingNodeList.class);
+    }
 }

--- a/core/src/main/java/com/platon/protocol/core/Platon.java
+++ b/core/src/main/java/com/platon/protocol/core/Platon.java
@@ -1,5 +1,6 @@
 package com.platon.protocol.core;
 
+import com.platon.protocol.core.methods.DebugWaitSlashingNodeList;
 import com.platon.protocol.core.methods.request.ShhFilter;
 import com.platon.protocol.core.methods.response.*;
 
@@ -130,4 +131,8 @@ public interface Platon {
     Request<?, AdminSchnorrNIZKProve> getSchnorrNIZKProve();
     
     Request<?, DebugEconomicConfig> getEconomicConfig();
+
+    Request<?, PlatonChainId> getChainId();
+
+    Request<?, DebugWaitSlashingNodeList> getWaitSlashingNodeList();
 }

--- a/core/src/main/java/com/platon/protocol/core/methods/DebugWaitSlashingNodeList.java
+++ b/core/src/main/java/com/platon/protocol/core/methods/DebugWaitSlashingNodeList.java
@@ -1,0 +1,17 @@
+package com.platon.protocol.core.methods;
+
+import com.platon.protocol.core.Response;
+import com.platon.protocol.core.methods.response.bean.WaitSlashingNode;
+import com.platon.utils.JSONUtil;
+
+import java.util.List;
+
+/**
+ * debug_getWaitSlashingNodeList
+ */
+public class DebugWaitSlashingNodeList extends Response<String> {
+
+    public List<WaitSlashingNode> get() {
+        return JSONUtil.parseArray(getResult(), WaitSlashingNode.class);
+    }
+}

--- a/core/src/main/java/com/platon/protocol/core/methods/response/PlatonChainId.java
+++ b/core/src/main/java/com/platon/protocol/core/methods/response/PlatonChainId.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.platon.protocol.core.methods.response;
+
+
+import com.platon.protocol.core.Response;
+import com.platon.utils.Numeric;
+
+import java.math.BigInteger;
+
+/** platon_chainId. */
+public class PlatonChainId extends Response<String> {
+    public BigInteger getChainId() {
+        return Numeric.decodeQuantity(getResult());
+    }
+}

--- a/core/src/main/java/com/platon/protocol/core/methods/response/bean/WaitSlashingNode.java
+++ b/core/src/main/java/com/platon/protocol/core/methods/response/bean/WaitSlashingNode.java
@@ -1,0 +1,64 @@
+package com.platon.protocol.core.methods.response.bean;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigInteger;
+
+/**
+ * @Author liushuyu
+ * @Date 2021/7/6 14:38
+ * @Version
+ * @Desc
+ */
+public class WaitSlashingNode {
+
+    //零出块的节点ID
+    @JsonProperty("NodeId")
+    private String nodeId;
+
+    //观察期内第一次零出块时所处共识轮数
+    @JsonProperty("Round")
+    private BigInteger round;
+
+    //零出块次数位图（从Round开始，1表示该轮未出块）
+    @JsonProperty("CountBit")
+    private BigInteger countBit;
+
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    @JsonIgnore
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public BigInteger getRound() {
+        return round;
+    }
+
+    @JsonIgnore
+    public void setRound(BigInteger round) {
+        this.round = round;
+    }
+
+    public BigInteger getCountBit() {
+        return countBit;
+    }
+
+    @JsonIgnore
+    public void setCountBit(BigInteger countBit) {
+        this.countBit = countBit;
+    }
+
+    @Override
+    public String toString() {
+        return "WaitSlashingNode{" +
+                "nodeId='" + nodeId + '\'' +
+                ", round=" + round +
+                ", countBit=" + countBit +
+                '}';
+    }
+}

--- a/core/src/main/java/com/platon/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/com/platon/protocol/websocket/WebSocketService.java
@@ -161,7 +161,7 @@ public class WebSocketService implements Web3jService {
         executor.schedule(
                 () -> closeRequest(
                     requestId,
-                    new SocketTimeoutException(
+                    new IOException(
                         String.format("Request with id %d timed out", requestId))),
                 REQUEST_TIMEOUT,
                 TimeUnit.SECONDS);

--- a/core/src/main/java/com/platon/protocol/websocket/WebSocketService.java
+++ b/core/src/main/java/com/platon/protocol/websocket/WebSocketService.java
@@ -17,6 +17,7 @@ import rx.subjects.BehaviorSubject;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -160,7 +161,7 @@ public class WebSocketService implements Web3jService {
         executor.schedule(
                 () -> closeRequest(
                     requestId,
-                    new IOException(
+                    new SocketTimeoutException(
                         String.format("Request with id %d timed out", requestId))),
                 REQUEST_TIMEOUT,
                 TimeUnit.SECONDS);

--- a/core/src/main/java/com/platon/tx/Contract.java
+++ b/core/src/main/java/com/platon/tx/Contract.java
@@ -268,7 +268,7 @@ public abstract class Contract extends ManagedTransaction {
         return contract;
     }
 
-    protected static <T extends Contract> T deploy(Class<T> type, Web3j web3j, Credentials credentials, GasProvider contractGasProvider, String binary, String encodedConstructor, BigInteger value) throws RuntimeException, TransactionException {
+    protected static <T extends Contract> T deploy(Class<T> type, Web3j web3j, Credentials credentials, GasProvider contractGasProvider, String binary, String encodedConstructor, BigInteger value) throws RuntimeException, TransactionException, IOException {
 
         try {
             Constructor<T> constructor = type.getDeclaredConstructor(String.class, Web3j.class, Credentials.class, GasProvider.class);
@@ -280,12 +280,14 @@ public abstract class Contract extends ManagedTransaction {
             return create(contract, binary, encodedConstructor, value);
         } catch (TransactionException e) {
             throw e;
+        } catch (IOException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    protected static <T extends Contract> T deploy(Class<T> type, Web3j web3j, TransactionManager transactionManager, GasProvider contractGasProvider, String binary, String encodedConstructor, BigInteger value) throws RuntimeException, TransactionException {
+    protected static <T extends Contract> T deploy(Class<T> type, Web3j web3j, TransactionManager transactionManager, GasProvider contractGasProvider, String binary, String encodedConstructor, BigInteger value) throws RuntimeException, TransactionException, IOException{
 
         try {
             Constructor<T> constructor = type.getDeclaredConstructor(String.class, Web3j.class, TransactionManager.class, GasProvider.class);
@@ -295,6 +297,8 @@ public abstract class Contract extends ManagedTransaction {
             T contract = constructor.newInstance(null, web3j, transactionManager, contractGasProvider);
             return create(contract, binary, encodedConstructor, value);
         } catch (TransactionException e) {
+            throw e;
+        } catch (IOException e) {
             throw e;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/core/src/main/java/com/platon/tx/WasmContract.java
+++ b/core/src/main/java/com/platon/tx/WasmContract.java
@@ -9,6 +9,7 @@ import com.platon.protocol.Web3j;
 import com.platon.protocol.core.DefaultBlockParameter;
 import com.platon.protocol.core.DefaultBlockParameterName;
 import com.platon.protocol.core.RemoteCall;
+import com.platon.protocol.core.Response;
 import com.platon.protocol.core.methods.request.Transaction;
 import com.platon.protocol.core.methods.response.Log;
 import com.platon.protocol.core.methods.response.PlatonCall;
@@ -19,8 +20,11 @@ import com.platon.rlp.wasm.RLPCodec;
 import com.platon.rlp.wasm.RLPList;
 import com.platon.rlp.wasm.datatypes.Int;
 import com.platon.rlp.wasm.datatypes.Uint;
+import com.platon.tx.exceptions.PlatonCallException;
+import com.platon.tx.exceptions.PlatonCallTimeoutException;
 import com.platon.tx.gas.GasProvider;
 import com.platon.utils.Numeric;
+import com.platon.utils.Strings;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -126,6 +130,20 @@ public abstract class WasmContract extends ManagedTransaction {
 				.platonCall(Transaction.createEthCallTransaction(transactionManager.getFromAddress(), contractAddress, encodedFunction),
 						defaultBlockParameter)
 				.send();
+
+		//判断底层返回的错误信息是否包含超时信息
+		if(ethCall.hasError()){
+			Response.Error error = ethCall.getError();
+			String message = error.getMessage();
+			String lowMessage = !Strings.isBlank(message)? message.toLowerCase() : null;
+			//包含timeout则抛超时异常，其他错误则直接抛出runtime异常
+			if(!Strings.isBlank(lowMessage)
+					&& lowMessage.contains("timeout")){
+				throw new PlatonCallTimeoutException(error.getCode(),error.getMessage(),ethCall);
+			} else {
+				throw new PlatonCallException(error.getCode(),error.getMessage(),ethCall);
+			}
+		}
 
 		String value = ethCall.getValue();
 		if (null != function.getOutputParameterizedType()) {

--- a/core/src/main/java/com/platon/tx/exceptions/PlatonCallException.java
+++ b/core/src/main/java/com/platon/tx/exceptions/PlatonCallException.java
@@ -1,0 +1,44 @@
+package com.platon.tx.exceptions;
+
+import com.platon.protocol.core.Response;
+
+import java.io.IOException;
+
+/**
+ * @Author liushuyu
+ * @Date 2021/5/12 16:46
+ * @Version
+ * @Desc
+ */
+public class PlatonCallException extends RuntimeException {
+
+    private Response response;
+    private int code;
+    private String msg;
+
+    public PlatonCallException(int code, String msg, Response response){
+        this.code = code;
+        this.msg = msg;
+        this.response = response;
+    }
+
+    public PlatonCallException(int code, String msg, Response response, Throwable ex){
+        super(ex);
+        this.code = code;
+        this.msg = msg;
+        this.response = response;
+    }
+
+    public Response getResponse() {
+        return response;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+}

--- a/core/src/main/java/com/platon/tx/exceptions/PlatonCallTimeoutException.java
+++ b/core/src/main/java/com/platon/tx/exceptions/PlatonCallTimeoutException.java
@@ -1,0 +1,44 @@
+package com.platon.tx.exceptions;
+
+import com.platon.protocol.core.Response;
+
+import java.io.IOException;
+
+/**
+ * @Author liushuyu
+ * @Date 2021/5/12 16:46
+ * @Version
+ * @Desc
+ */
+public class PlatonCallTimeoutException extends IOException {
+
+    private Response response;
+    private int code;
+    private String msg;
+
+    public PlatonCallTimeoutException(int code,String msg,Response response){
+        this.code = code;
+        this.msg = msg;
+        this.response = response;
+    }
+
+    public PlatonCallTimeoutException(int code,String msg,Response response,Throwable ex){
+        super(ex);
+        this.code = code;
+        this.msg = msg;
+        this.response = response;
+    }
+
+    public Response getResponse() {
+        return response;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+}

--- a/crypto/src/main/java/com/platon/crypto/WalletUtils.java
+++ b/crypto/src/main/java/com/platon/crypto/WalletUtils.java
@@ -17,6 +17,8 @@ import java.security.SecureRandom;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.platon.crypto.Hash.sha256;
 import static com.platon.crypto.Keys.ADDRESS_LENGTH_IN_HEX;
@@ -264,6 +266,12 @@ public class WalletUtils {
     }
 
     public static boolean isValidAddress(String input) {
+        //exclude blank characters and uppercase letters
+        Pattern pattern = Pattern.compile("^[a-z0-9]+$");
+        Matcher matcher = pattern.matcher(input);
+        if(!matcher.find()){
+            return false;
+        }
         String cleanInput;
         try{
             byte [] bytes = Bech32.addressDecode(input);

--- a/doc/Java-SDK-en.md
+++ b/doc/Java-SDK-en.md
@@ -26,7 +26,7 @@ Depending on the build tool, use the following methods to add related dependenci
 <dependency>
     <groupId>com.platon.sdk</groupId>
     <artifactId>core</artifactId>
-    <version>0.15.1.9</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -41,7 +41,7 @@ repositories {
 
 > gradle way of reference:
 ```
-compile "com.platon.client:core:0.15.1.9"
+compile "com.platon.client:core:1.1.0"
 ```
 
 ## Basic API Usage
@@ -1373,6 +1373,55 @@ Web3j platonWeb3j = Web3j.build(new HttpService("http://127.0.0.1:6789"));
 Request<?, DebugEconomicConfig> req = currentValidWeb3j.getEconomicConfig();
 String debugEconomicConfig = req.send().getEconomicConfigStr();
 ```
+
+
+### getChainId
+
+> Get chain ID
+- **parameters**
+
+  no
+
+- **return value**
+
+```java
+Request<?, PlatonChainId>
+```
+
+The String in the PlatonChainId property is the corresponding stored data
+
+- **Example**
+
+```java
+Web3j platonWeb3j = Web3j.build(new HttpService("http://127.0.0.1:6789"));
+Request<?, PlatonChainId> req = platonWeb3j.getChainId();
+BigInteger chainId = req.send().getChainId();
+```
+
+### getWaitSlashingNodeList
+
+>    Get the node with zero block, the list of nodes that are observed because of zero block
+
+* **parameters**
+
+  no
+
+* **return value**
+
+```java
+Request<?, DebugWaitSlashingNodeList>
+```
+
+The `WaitSlashingNode` List Object in the `DebugWaitSlashingNodeList` property is the corresponding stored data
+
+* **Example**
+
+```java
+Web3j platonWeb3j = Web3j.build(new HttpService("http://127.0.0.1:6789"));
+Request<?, DebugWaitSlashingNodeList> req = platonWeb3j.getWaitSlashingNodeList();
+DebugWaitSlashingNodeList nodeList = req.send();
+```
+
 
 ## System Contract Call
 

--- a/doc/Java-SDK-en.md
+++ b/doc/Java-SDK-en.md
@@ -26,7 +26,7 @@ Depending on the build tool, use the following methods to add related dependenci
 <dependency>
     <groupId>com.platon.sdk</groupId>
     <artifactId>core</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.0.0</version>
 </dependency>
 ```
 
@@ -41,7 +41,7 @@ repositories {
 
 > gradle way of reference:
 ```
-compile "com.platon.client:core:1.1.0"
+compile "com.platon.client:core:1.1.0.0"
 ```
 
 ## Basic API Usage
@@ -1461,7 +1461,7 @@ StakingContract contract = StakingContract.load(web3j, credentials);
 
   - String: nodeId node id, hexadecimal format
   - BigInteger: amount of von pledged, the pledged amount must be greater than or equal to 1,000,000 LAT
-  - StakingAmountType: stakingAmountType, enumeration, FREE_AMOUNT_TYPE means use the free amount of the account, RESTRICTING_AMOUNT_TYPE means use the amount of the lock to make a pledge
+  - StakingAmountType: stakingAmountType, enumeration, FREE_AMOUNT_TYPE means use the free amount of the account, RESTRICTING_AMOUNT_TYPE means use the amount of the lock to make a pledge, AUTO_AMOUNT_TYPE means give priority to the use of the locked balance, and use the free amount for the remaining part if the locked balance is insufficient
   - String: benefitAddress revenue account
   - String: nodeName The name of the node being pledged
   - String: externalId External Id(the length of the Id described by the third-party pull node), currently the keybase account public key

--- a/doc/Java-SDK-zh.md
+++ b/doc/Java-SDK-zh.md
@@ -26,7 +26,7 @@ sidebar_label: Java SDK
 <dependency>
     <groupId>com.platon.sdk</groupId>
     <artifactId>core</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.0.0</version>
 </dependency>
 ```
 
@@ -41,7 +41,7 @@ repositories {
 
 > gradle引用方式:
 ```
-compile "com.platon.sdk:core:1.1.0"
+compile "com.platon.sdk:core:1.1.0.0"
 ```
 
 ## 基础api使用
@@ -1458,7 +1458,7 @@ StakingContract stakingContract = StakingContract.load(web3j, credentials);
 
   - String：nodeId   节点id，16进制格式，即节点公钥，可以通过管理台查询（platon attach http://127.0.0.1:6789 --exec "admin.nodeInfo.id"）。
   - BigInteger：stakingAmount  质押的金额，单位VON，默认质押金额必须大于等于1000000LAT，该大小限制可以通过治理参数动态调整，可通过治理接口获得当前值（proposalContract.getGovernParamValue("staking", "stakeThreshold")）。
-  - StakingAmountType：stakingAmountType  表示使用账户自由金额还是账户的锁仓金额做质押，StakingAmountType.FREE_AMOUNT_TYPE：自由金额，StakingAmountType.RESTRICTING_AMOUNT_TYPE：锁仓金额
+  - StakingAmountType：stakingAmountType  表示使用账户自由金额还是账户的锁仓金额做质押，StakingAmountType.FREE_AMOUNT_TYPE：自由金额，StakingAmountType.RESTRICTING_AMOUNT_TYPE：锁仓金额，StakingAmountType.AUTO_AMOUNT_TYPE：优先使用锁仓余额，锁仓余额不足则剩下的部分使用自由金额
   - String：benifitAddress   收益账户，用于接收出块奖励和质押奖励的收益账户。
   - String：nodeName   节点的名称
   - String：externalId   外部Id(有长度限制，给第三方拉取节点描述的Id)，目前为keybase账户公钥，节点图标是通过该公钥获取。

--- a/doc/Java-SDK-zh.md
+++ b/doc/Java-SDK-zh.md
@@ -26,7 +26,7 @@ sidebar_label: Java SDK
 <dependency>
     <groupId>com.platon.sdk</groupId>
     <artifactId>core</artifactId>
-    <version>0.15.1.9</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -41,7 +41,7 @@ repositories {
 
 > gradle引用方式:
 ```
-compile "com.platon.sdk:core:0.15.1.9"
+compile "com.platon.sdk:core:1.1.0"
 ```
 
 ## 基础api使用
@@ -1371,6 +1371,53 @@ DebugEconomicConfig属性中的String即为对应存储数据
 Web3j platonWeb3j = Web3j.build(new HttpService("http://127.0.0.1:6789"));
 Request<?, DebugEconomicConfig> req = currentValidWeb3j.getEconomicConfig();
 String debugEconomicConfig = req.send().getEconomicConfigStr();
+```
+
+### getChainId
+
+>    获取链ID
+* **参数**
+
+  无
+
+* **返回值**
+
+```java
+Request<?, PlatonChainId>
+```
+
+PlatonChainId属性中的String即为对应存储数据
+
+* **示例**
+
+```java
+Web3j platonWeb3j = Web3j.build(new HttpService("http://127.0.0.1:6789"));
+Request<?, PlatonChainId> req = platonWeb3j.getChainId();
+BigInteger chainId = req.send().getChainId();
+```
+
+### getWaitSlashingNodeList
+
+>    获取零出块的节点，因为零出块而被观察的节点列表
+
+* **参数**
+
+  无
+
+* **返回值**
+
+```java
+Request<?, DebugWaitSlashingNodeList>
+```
+
+DebugWaitSlashingNodeList属性中的WaitSlashingNode列表对象即为对应存储数据
+
+* **示例**
+
+```java
+Web3j platonWeb3j = Web3j.build(new HttpService("http://127.0.0.1:6789"));
+Request<?, DebugWaitSlashingNodeList> req = platonWeb3j.getWaitSlashingNodeList();
+DebugWaitSlashingNodeList nodeList = req.send();
 ```
 
 ## 系统合约调用

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.platon.sdk
-version=0.15.2.0
+version=1.1.0
 mavenReleases=https://sdk.platon.network/nexus/content/repositories/releases/
 mavenSnapshots=https://sdk.platon.network/nexus/content/repositories/snapshots/
 systemProp.sonar.host.url=http://192.168.16.173:9000

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.platon.sdk
-version=0.15.1.10
+version=0.15.2.0
 mavenReleases=https://sdk.platon.network/nexus/content/repositories/releases/
 mavenSnapshots=https://sdk.platon.network/nexus/content/repositories/snapshots/
 systemProp.sonar.host.url=http://192.168.16.173:9000

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.platon.sdk
-version=1.1.0
+version=1.1.0.0
 mavenReleases=https://sdk.platon.network/nexus/content/repositories/releases/
 mavenSnapshots=https://sdk.platon.network/nexus/content/repositories/snapshots/
 systemProp.sonar.host.url=http://192.168.16.173:9000

--- a/integration-tests/src/test/java/com/platon/protocol/core/GasProviderTest.java
+++ b/integration-tests/src/test/java/com/platon/protocol/core/GasProviderTest.java
@@ -1,0 +1,129 @@
+package com.platon.protocol.core;
+
+import com.alibaba.fastjson.JSONObject;
+import com.platon.contracts.ppos.abi.Function;
+import com.platon.contracts.ppos.dto.resp.Proposal;
+import com.platon.contracts.ppos.utils.EncoderUtils;
+import com.platon.crypto.Credentials;
+import com.platon.parameters.NetworkParameters;
+import com.platon.protocol.Web3j;
+import com.platon.protocol.core.methods.request.Transaction;
+import com.platon.protocol.core.methods.response.PlatonChainId;
+import com.platon.protocol.core.methods.response.PlatonEstimateGas;
+import com.platon.protocol.http.HttpService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+/**
+ * @Author liushuyu
+ * @Date 2021/6/4 11:01
+ * @Version
+ * @Desc
+ */
+public class GasProviderTest {
+
+    @Before
+    public void init(){
+        NetworkParameters.selectPlatON();
+    }
+
+    /**
+     * 底层1.0.0版本
+     * @throws IOException
+     */
+    @Test
+    public void testGetProviderWithGasPrice_version1_0_0() throws Exception {
+        Web3j web3j = Web3j.build(new HttpService("http://192.168.120.150:6789"));
+        String fromAddr = Credentials.create("3a4130e4abb887a296eb38c15bbd83253ab09492a505b10a54b008b7dcc1668").getAddress();
+        String contractAddr = NetworkParameters.getPposContractAddressOfProposal();
+
+        String nodePublicKey = "8d4967ba21c46d63a352b7bccc47810ebdda7869861fbd341d50bfdeb4318e6e429749a3595102392921e434f8d46720af90d018da3a616f931597f57990ded0";
+        String pipId = "111";
+        String module = "staking";
+        String paramName = "stakeThreshold";
+        String paramValue = "1";
+        Proposal proposal =
+                Proposal.createSubmitParamProposalParam(
+                        nodePublicKey,
+                        pipId,
+                        module,
+                        paramName,
+                        paramValue);
+        Function function = new Function(proposal.getSubmitFunctionType(),
+                proposal.getSubmitInputParameters());
+        //BigInteger gasLimit = web3j.platonEstimateGas(transaction).send().getAmountUsed();
+        //gasPrice必须首先获得，在estimateGas的时候，治理合约就需要gasPrice。
+        //estimateGas的时候，交易的所有参数，除了gasLimit，应该和真正发送时的参数一样。
+        BigInteger gasPrice = BigInteger.valueOf(100000000000000L);
+
+        BigInteger gasLimit = null;
+        BigInteger nonce = null;
+
+        //String from, BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit, String to, String data
+        Transaction transaction = Transaction.createFunctionCallTransaction(fromAddr, nonce, gasPrice, gasLimit, contractAddr, EncoderUtils.functionEncoder(function));
+
+        PlatonEstimateGas platonEstimateGas = web3j.platonEstimateGas(transaction).send();
+
+        //不带gasprice 估算一次
+        Transaction transaction_noGasPrice = Transaction.createEthCallTransaction(fromAddr, contractAddr, EncoderUtils.functionEncoder(function));
+        PlatonEstimateGas platonEstimateGas_noGasPrice = web3j.platonEstimateGas(transaction_noGasPrice).send();
+
+        System.out.println("带gas Price：" + JSONObject.toJSONString(platonEstimateGas));
+        System.out.println("不带gas Price：" + JSONObject.toJSONString(platonEstimateGas_noGasPrice));
+        Assert.assertTrue(platonEstimateGas.getError() != null);
+        Assert.assertTrue(platonEstimateGas_noGasPrice.getError() != null);
+    }
+
+
+    /**
+     * 底层1.1.0版本
+     * @throws IOException
+     */
+    @Test
+    public void testGetProviderWithGasPrice_version1_1_0() throws Exception {
+        Web3j web3j = Web3j.build(new HttpService("http://192.168.120.150:6780"));
+        String fromAddr = Credentials.create("3a4130e4abb887a296eb38c15bbd83253ab09492a505b10a54b008b7dcc1668").getAddress();
+        String contractAddr = NetworkParameters.getPposContractAddressOfProposal();
+
+        String nodePublicKey = "0abaf3219f454f3d07b6cbcf3c10b6b4ccf605202868e2043b6f5db12b745df0604ef01ef4cb523adc6d9e14b83a76dd09f862e3fe77205d8ac83df707969b47";
+        String pipId = "111";
+        String module = "staking";
+        String paramName = "stakeThreshold";
+        String paramValue = "1";
+        Proposal proposal =
+                Proposal.createSubmitParamProposalParam(
+                        nodePublicKey,
+                        pipId,
+                        module,
+                        paramName,
+                        paramValue);
+        Function function = new Function(proposal.getSubmitFunctionType(),
+                proposal.getSubmitInputParameters());
+        //BigInteger gasLimit = web3j.platonEstimateGas(transaction).send().getAmountUsed();
+        //gasPrice必须首先获得，在estimateGas的时候，治理合约就需要gasPrice。
+        //estimateGas的时候，交易的所有参数，除了gasLimit，应该和真正发送时的参数一样。
+        BigInteger gasPrice = BigInteger.valueOf(100000000000000L);
+
+        BigInteger gasLimit = null;
+        BigInteger nonce = null;
+
+        //String from, BigInteger nonce, BigInteger gasPrice, BigInteger gasLimit, String to, String data
+        Transaction transaction = Transaction.createFunctionCallTransaction(fromAddr, nonce, gasPrice, gasLimit, contractAddr, EncoderUtils.functionEncoder(function));
+
+        PlatonEstimateGas platonEstimateGas = web3j.platonEstimateGas(transaction).send();
+
+        //不带gasprice 估算一次
+        Transaction transaction_noGasPrice = Transaction.createEthCallTransaction(fromAddr, contractAddr, EncoderUtils.functionEncoder(function));
+        PlatonEstimateGas platonEstimateGas_noGasPrice = web3j.platonEstimateGas(transaction_noGasPrice).send();
+
+        System.out.println("带gas Price：" + JSONObject.toJSONString(platonEstimateGas));
+        System.out.println("不带gas Price：" + JSONObject.toJSONString(platonEstimateGas_noGasPrice));
+        Assert.assertTrue(platonEstimateGas.getError() == null);
+        Assert.assertTrue(platonEstimateGas_noGasPrice.getError() == null);
+    }
+
+}

--- a/integration-tests/src/test/java/com/platon/protocol/core/JsonRpc2_0Web3jTest.java
+++ b/integration-tests/src/test/java/com/platon/protocol/core/JsonRpc2_0Web3jTest.java
@@ -1,0 +1,76 @@
+package com.platon.protocol.core;
+
+import com.platon.parameters.NetworkParameters;
+import com.platon.protocol.Web3j;
+import com.platon.protocol.core.methods.DebugWaitSlashingNodeList;
+import com.platon.protocol.core.methods.response.PlatonChainId;
+import com.platon.protocol.http.HttpService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * @Author liushuyu
+ * @Date 2021/7/6 15:52
+ * @Version
+ * @Desc
+ */
+public class JsonRpc2_0Web3jTest {
+
+    private static final Logger logger = LoggerFactory.getLogger("JsonRpc2_0Web3jTest");
+
+    @Before
+    public void init(){
+        NetworkParameters.selectPlatON();
+    }
+
+    /**
+     * 底层1.0.0版本
+     * @throws IOException
+     */
+    @Test
+    public void testChainId_version1_0_0() throws IOException {
+        Web3j web3j = Web3j.build(new HttpService("http://192.168.120.150:6789"));
+        PlatonChainId send = web3j.getChainId().send();
+        Assert.assertTrue(send.getError() != null);
+    }
+
+    /**
+     * 底层1.1.0版本
+     * @throws IOException
+     */
+    @Test
+    public void testChainId_version1_1_0() throws IOException {
+        Web3j web3j = Web3j.build(new HttpService("http://192.168.120.150:6780"));
+        PlatonChainId send = web3j.getChainId().send();
+        Assert.assertTrue(send.getError() == null);
+    }
+
+    /**
+     * 底层1.0.0版本
+     * @throws IOException
+     */
+    @Test
+    public void testGetWaitSlashingNodeList_version1_0_0() throws IOException {
+        Web3j web3j = Web3j.build(new HttpService("http://192.168.120.150:6789"));
+        DebugWaitSlashingNodeList nodeList = web3j.getWaitSlashingNodeList().send();
+        Assert.assertTrue(nodeList.getResult() != null);
+        Assert.assertTrue(nodeList.getError() == null);
+    }
+
+    /**
+     * 底层1.1.0版本
+     * @throws IOException
+     */
+    @Test
+    public void testGetWaitSlashingNodeList_version1_1_0() throws IOException {
+        Web3j web3j = Web3j.build(new HttpService("http://192.168.120.150:6780"));
+        DebugWaitSlashingNodeList nodeList = web3j.getWaitSlashingNodeList().send();
+        Assert.assertTrue(nodeList.getResult() != null);
+        Assert.assertTrue(nodeList.getError() == null);
+    }
+}


### PR DESCRIPTION
1. When executing the contract method, if the error message returned by the bottom layer is a timeout message, PlatonCallTimeoutException will be returned, and other error messages will be returned PlatonCallException
2. The previous contract deployment timeout will return a RuntimeException, now the contract deployment timeout will return an IOException
3. Increase the verification rule of the WalletUtils.isValidAddress method for capital letters, the wallet address containing capital letters will fail the verification
4. Fix the execution of contract method, when the gas price is not passed to get the default gasProvider, it prompts that gas price is lower than minimum
5. Added rpc interface for obtaining chainId
6. Added a new interface to get the node list with zero block
###################################################
1.执行合约方法时，如果底层返回的错误信息为超时信息则会返回PlatonCallTimeoutException，其他错误信息则返回PlatonCallException
2.之前的合约部署超时会返回一个RuntimeException，现在合约部署超时会返回一个IOException
3.增加WalletUtils.isValidAddress方法对大写字母的校验规则，钱包地址包含大写字母将会校验不通过
4.修复合约方法执行，未传gas price获取默认gasProvider时，提示gas price is lower than minimum
5.新增获取chainId的rpc接口
6.新增获取零出块的节点列表接口